### PR TITLE
Fix installing extended version on MacOS

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -76,8 +76,8 @@ download_release() {
   local version_path="${version//extended_/}"
   local filename="$2"
   local platform=$(get_platform)
-  local major_version=$(echo "$version" | awk -F. '{print $1}')
-  local minor_version=$(echo "$version" | awk -F. '{print $2}')
+  local major_version=$(echo "$version_path" | awk -F. '{print $1}')
+  local minor_version=$(echo "$version_path" | awk -F. '{print $2}')
 
   # For Mac downloads use universal binaries for releases >= 0.102.0
   if [ "${platform}" = "darwin" ] && [ "${major_version}" -eq "0" ] && [ "${minor_version}" -ge "102" ]; then


### PR DESCRIPTION
Attempting to install and extended version with MacOS fails

```sh
/Users/jonjon/.asdf/plugins/hugo/bin/../lib/utils.bash: line 83: [: extended_0: integer expression expected
/Users/jonjon/.asdf/plugins/hugo/bin/../lib/utils.bash: line 90: [: extended_0: integer expression expected
* Downloading hugo release extended_0.106.0...
curl: (22) The requested URL returned error: 404
asdf-hugo: Could not download https://github.com/gohugoio/hugo/releases/download/v0.106.0/hugo_extended_0.106.0_darwin-ARM64.tar.gz
```

This is because it is using the full `extended_X.Y.Z` version when parsing major/minor version and the checks fail, forcing it to use the arch of the system which is incorrect.

This fixes that to use the parsed `X.Y.Z` `version_path` in major/minor