### PR TITLE
feat(macOS): handle pkg installation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
+        uses: asdf-vm/actions/plugin-test@v4
         with:
           command: hugo version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Run ShellCheck
         run: shellcheck -x bin/*
 
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Install shfmt
         run: brew install shfmt
       - name: Run shfmt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Run ShellCheck
-        run: shellcheck -x bin/*
+        run: shellcheck -x bin/* lib/*
 
   format:
     runs-on: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,12 @@ name: Release
 on:
   push:
     branches:
-      - master 
+      - master
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2
+      - uses: GoogleCloudPlatform/release-please-action@v4
         with:
           release-type: simple

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 shellcheck 0.11.0
-shfmt 3.12.0
+shfmt      3.12.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-shellcheck 0.7.2
-shfmt 3.2.4
+shellcheck 0.11.0
+shfmt 3.12.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 shellcheck 0.11.0
-shfmt      3.12.0
+shfmt 3.12.0

--- a/bin/download
+++ b/bin/download
@@ -7,14 +7,16 @@ source "$(dirname "$0")/../lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-# Adapt this to proper extension and adapt extracting strategy.
-release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
+# Determine proper extension for the requested version (tar.gz or pkg)
+ext=$(get_release_ext "$ASDF_INSTALL_VERSION")
+release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.$ext"
 
-# Download tar.gz file to the download directory
+# Download release file to the download directory
 download_release "$ASDF_INSTALL_VERSION" "$release_file"
 
-# Extract contents of tar.gz file into the download directory
-tar -zxvf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
-
-# Remove the tar.gz file since we don't need to keep it
-rm "$release_file"
+# If the downloaded file is a tarball, extract it; for pkg on macOS leave it as-is
+if [ "$ext" = "tar.gz" ]; then
+  tar -zxvf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+  # Remove the tar.gz file since we don't need to keep it
+  rm "$release_file"
+fi

--- a/bin/download
+++ b/bin/download
@@ -13,10 +13,3 @@ release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.$ext"
 
 # Download release file to the download directory
 download_release "$ASDF_INSTALL_VERSION" "$release_file"
-
-# If the downloaded file is a tarball, extract it; for pkg on macOS leave it as-is
-if [ "$ext" = "tar.gz" ]; then
-  tar -zxvf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
-  # Remove the tar.gz file since we don't need to keep it
-  rm "$release_file"
-fi

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -138,7 +138,6 @@ extract_release() {
     gzip -dc "$ASDF_DOWNLOAD_PATH/Payload" | (cd "$ASDF_DOWNLOAD_PATH" && cpio -idm ./hugo) >/dev/null 2>&1 ||
       fail "Could not extract hugo from Payload $filename"
 
-    rm -f "$ASDF_DOWNLOAD_PATH/Payload"
     # Clean up xar-extracted metadata files to keep the download path tidy
     rm -f "$ASDF_DOWNLOAD_PATH/Payload" \
           "$ASDF_DOWNLOAD_PATH/PackageInfo" \

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -124,8 +124,7 @@ download_release() {
 }
 
 # Extract a downloaded release (tar.gz or pkg) and place the `hugo` binary
-# at $ASDF_DOWNLOAD_PATH/$TOOL_NAME (executable). This makes installation
-# a simple copy regardless of package format.
+# at $ASDF_DOWNLOAD_PATH/$TOOL_NAME
 extract_release() {
   local filename="$1"
 
@@ -139,20 +138,12 @@ extract_release() {
     gzip -dc "$ASDF_DOWNLOAD_PATH/Payload" | (cd "$ASDF_DOWNLOAD_PATH" && cpio -idmv ./hugo) >/dev/null 2>&1 ||
       fail "Could not extract hugo from Payload $filename"
 
-    [ -f "$ASDF_DOWNLOAD_PATH/$TOOL_NAME" ] || fail "hugo not found after extracting $filename"
-    chmod +x "$ASDF_DOWNLOAD_PATH/$TOOL_NAME"
     rm -f "$ASDF_DOWNLOAD_PATH/Payload"
 
   elif [[ "$filename" == *.tar.gz ]]; then
-    # Extract directly into the ASDF download path (previous simple behavior)
+    # Extract directly into the ASDF download path
     tar -xzf "$filename" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $filename"
-    # Expect the hugo executable to be at the root of $ASDF_DOWNLOAD_PATH
-    if [ -f "$ASDF_DOWNLOAD_PATH/$TOOL_NAME" ]; then
-      chmod +x "$ASDF_DOWNLOAD_PATH/$TOOL_NAME"
-      rm -f "$filename"
-    else
-      fail "hugo not found after extracting $filename"
-    fi
+    rm -f "$filename"
 
   else
     fail "Unknown release format for $filename"
@@ -177,9 +168,12 @@ install_version() {
 
     extract_release "$release_file"
 
+    # Ensure hugo executable exists and make it executable
+    [ -f "$ASDF_DOWNLOAD_PATH/$TOOL_NAME" ] || fail "hugo executablenot found after extracting $release_file"
+    chmod +x "$ASDF_DOWNLOAD_PATH/$TOOL_NAME"
+
     cp -r "$ASDF_DOWNLOAD_PATH/$TOOL_NAME" "$install_path/bin/"
 
-    # Assert hugo executable exists
     local tool_cmd
     tool_cmd=$(echo "$TOOL_TEST" | cut -d' ' -f1)
     test -x "$install_path/bin/$tool_cmd" || fail "Expected $install_path/bin/$tool_cmd to be executable."

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -136,7 +136,7 @@ extract_release() {
     [ -f "$ASDF_DOWNLOAD_PATH/Payload" ] || fail "Payload not found inside pkg $filename"
 
     # Extract only the hugo file from the Payload into the download path
-    gzip -dc "$ASDF_DOWNLOAD_PATH/Payload" | (cd "$ASDF_DOWNLOAD_PATH" && cpio -idmv ./hugo) >/dev/null 2>&1 || \
+    gzip -dc "$ASDF_DOWNLOAD_PATH/Payload" | (cd "$ASDF_DOWNLOAD_PATH" && cpio -idmv ./hugo) >/dev/null 2>&1 ||
       fail "Could not extract hugo from Payload $filename"
 
     [ -f "$ASDF_DOWNLOAD_PATH/$TOOL_NAME" ] || fail "hugo not found after extracting $filename"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -140,8 +140,8 @@ extract_release() {
 
     # Clean up xar-extracted metadata files to keep the download path tidy
     rm -f "$ASDF_DOWNLOAD_PATH/Payload" \
-          "$ASDF_DOWNLOAD_PATH/PackageInfo" \
-          "$ASDF_DOWNLOAD_PATH/Distribution"
+      "$ASDF_DOWNLOAD_PATH/PackageInfo" \
+      "$ASDF_DOWNLOAD_PATH/Distribution"
     rm -rf "$ASDF_DOWNLOAD_PATH/Resources" "$ASDF_DOWNLOAD_PATH/Scripts"
 
     # Remove the original pkg file now that we have extracted hugo

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -32,7 +32,8 @@ list_github_tags() {
 
 list_all_versions() {
   # Change this function if hugo has other means of determining installable versions.
-  local tags=$(list_github_tags)
+  local tags
+  tags=$(list_github_tags)
   echo "$tags"
 }
 
@@ -40,9 +41,12 @@ list_all_versions() {
 get_release_ext() {
   local version="$1"
   local version_path="${version//extended_/}"
-  local major_version=$(echo "$version_path" | awk -F. '{print $1}')
-  local minor_version=$(echo "$version_path" | awk -F. '{print $2}')
-  local platform=$(get_platform)
+  local major_version
+  major_version=$(echo "$version_path" | awk -F. '{print $1}')
+  local minor_version
+  minor_version=$(echo "$version_path" | awk -F. '{print $2}')
+  local platform
+  platform=$(get_platform)
 
   # For macOS (darwin) use .pkg for Hugo minor versions greater than 153
   if [ "${platform}" = "darwin" ] && [ "${major_version}" -eq "0" ] && [ "${minor_version}" -gt "153" ]; then
@@ -91,15 +95,19 @@ download_release() {
   local version="$1"
   local version_path="${version//extended_/}"
   local filename="$2"
-  local platform=$(get_platform)
-  local major_version=$(echo "$version_path" | awk -F. '{print $1}')
-  local minor_version=$(echo "$version_path" | awk -F. '{print $2}')
+  local platform
+  platform=$(get_platform)
+  local major_version
+  major_version=$(echo "$version_path" | awk -F. '{print $1}')
+  local minor_version
+  minor_version=$(echo "$version_path" | awk -F. '{print $2}')
 
   # For Mac downloads use universal binaries for releases >= 0.102.0
+  local arch
   if [ "${platform}" = "darwin" ] && [ "${major_version}" -eq "0" ] && [ "${minor_version}" -ge "102" ]; then
-    local arch="universal"
+    arch="universal"
   else
-    local arch=$(get_arch)
+    arch=$(get_arch)
   fi
 
   # v0.103.0 changed naming conventions on the Hugo releases. This reverts if trying to install older version of Hugo.
@@ -107,11 +115,48 @@ download_release() {
     local platform="macOS"
   fi
 
-  local ext=$(get_release_ext "$version")
+  local ext
+  ext=$(get_release_ext "$version")
   local url="${GH_REPO}/releases/download/v${version_path}/hugo_${version}_${platform}-${arch}.${ext}"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
+}
+
+# Extract a downloaded release (tar.gz or pkg) and place the `hugo` binary
+# at $ASDF_DOWNLOAD_PATH/$TOOL_NAME (executable). This makes installation
+# a simple copy regardless of package format.
+extract_release() {
+  local filename="$1"
+
+  mkdir -p "$ASDF_DOWNLOAD_PATH"
+  if [[ "$filename" == *.pkg ]]; then
+    # Extract xar entries directly into the ASDF download path
+    (cd "$ASDF_DOWNLOAD_PATH" && xar -xf "$filename") || fail "Could not extract xar from $filename"
+    [ -f "$ASDF_DOWNLOAD_PATH/Payload" ] || fail "Payload not found inside pkg $filename"
+
+    # Extract only the hugo file from the Payload into the download path
+    gzip -dc "$ASDF_DOWNLOAD_PATH/Payload" | (cd "$ASDF_DOWNLOAD_PATH" && cpio -idmv ./hugo) >/dev/null 2>&1 || \
+      fail "Could not extract hugo from Payload $filename"
+
+    [ -f "$ASDF_DOWNLOAD_PATH/$TOOL_NAME" ] || fail "hugo not found after extracting $filename"
+    chmod +x "$ASDF_DOWNLOAD_PATH/$TOOL_NAME"
+    rm -f "$ASDF_DOWNLOAD_PATH/Payload"
+
+  elif [[ "$filename" == *.tar.gz ]]; then
+    # Extract directly into the ASDF download path (previous simple behavior)
+    tar -xzf "$filename" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $filename"
+    # Expect the hugo executable to be at the root of $ASDF_DOWNLOAD_PATH
+    if [ -f "$ASDF_DOWNLOAD_PATH/$TOOL_NAME" ]; then
+      chmod +x "$ASDF_DOWNLOAD_PATH/$TOOL_NAME"
+      rm -f "$filename"
+    else
+      fail "hugo not found after extracting $filename"
+    fi
+
+  else
+    fail "Unknown release format for $filename"
+  fi
 }
 
 install_version() {
@@ -125,18 +170,18 @@ install_version() {
 
   (
     mkdir -p "$install_path/bin"
+    # Ensure the release is extracted and the `hugo` binary is available
+    ext=$(get_release_ext "$version")
+    release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$version.$ext"
+    [ -f "$release_file" ] || fail "Release file for $TOOL_NAME $version not found in $ASDF_DOWNLOAD_PATH"
 
-    # If a macOS .pkg was downloaded use the system installer.
-    pkg_file=$(ls "$ASDF_DOWNLOAD_PATH"/hugo_*"${version}"*.pkg 2>/dev/null || true)
-    if [ -n "${pkg_file}" ]; then
-      echo "* Installing $TOOL_NAME from pkg ${pkg_file} to ${install_path}..."
-      installer -pkg "${pkg_file}" -target "${install_path}" || fail "Failed to run installer on ${pkg_file}"
-    else
-      cp -r "$ASDF_DOWNLOAD_PATH/$TOOL_NAME" "$install_path/bin/"
-    fi
+    extract_release "$release_file"
+
+    cp -r "$ASDF_DOWNLOAD_PATH/$TOOL_NAME" "$install_path/bin/"
 
     # Assert hugo executable exists
-    local tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
+    local tool_cmd
+    tool_cmd=$(echo "$TOOL_TEST" | cut -d' ' -f1)
     test -x "$install_path/bin/$tool_cmd" || fail "Expected $install_path/bin/$tool_cmd to be executable."
 
     echo "$TOOL_NAME $version installation was successful!"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -157,7 +157,6 @@ extract_release() {
     # Extract directly into the ASDF download path
     tar -xzf "$filename" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $filename"
     rm -f "$filename"
-
   else
     fail "Unknown release format for $filename"
   fi


### PR DESCRIPTION
The main change in this PR is fixing #8 by downloading, extracting, and installing `.pkg` files on macOS for Hugo versions greater than v0.153. I have tested this manually with both [https://github.com/asdf-vm/asdf](https://github.com/asdf-vm/asdf) and [https://github.com/jdx/mise](https://github.com/jdx/mise) on macOS and Fedora. It seems to be working fine, but I would welcome further testing from folks more familiar with asdf and Hugo.

I also took the opportunity to bring some of the GitHub Actions plugins, linters, and formatting tools up to date, and to make sure that ShellCheck is also run against `utils.bash` as part of the CI Pipeline. Finally I've enabled Dependabot to keep up with updates. 

---

_The change description below has been AI-generated (and reviewed by me):_
 
This pull request updates CI workflows, tool versions, and improves the installation logic for the Hugo plugin. The most significant changes are grouped below:

**Hugo Installation Improvements:**

* Added `get_release_ext` and `extract_release` functions in `lib/utils.bash` to support downloading and extracting both `.tar.gz` and `.pkg` release formats, improving compatibility with newer Hugo releases on macOS. [[1]](diffhunk://#diff-837b8f846cf319a2535e7719b9a7a34e8316e7472abea31f0f786440d0c30dd6L35-R58) [[2]](diffhunk://#diff-837b8f846cf319a2535e7719b9a7a34e8316e7472abea31f0f786440d0c30dd6L78-R152)
* Refactored `install_version` to use the new extraction logic and ensure the `hugo` binary is correctly installed and executable.

**CI Workflow Upgrades:**

* Updated GitHub Actions versions in `.github/workflows/build.yml`, `.github/workflows/lint.yml`, and `.github/workflows/release.yml` to use newer, more secure releases for `asdf-vm/actions/plugin-test`, `actions/checkout`, and `GoogleCloudPlatform/release-please-action`. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L21-R21) [[2]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L15-R23) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L12-R12)
* Added a `.github/dependabot.yml` configuration to enable automatic dependency updates for GitHub Actions workflows.

**Tool Version Updates:**

* Upgraded `shellcheck` to version 0.11.0 and `shfmt` to version 3.12.0 in `.tool-versions` for improved linting and formatting capabilities.