### PR TITLE
ci: downgrade asdf plugin test action to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v4
+        uses: asdf-vm/actions/plugin-test@v3
         with:
           command: hugo version


### PR DESCRIPTION
Looks like builds are failing (https://github.com/NeoHsu/asdf-hugo/actions/runs/20704098959) due to an underlying bug in asdf-vm/actions/plugin-test@v4 (see: asdf-vm/actions#595).

Downgrading to v3 fixes the build