### PR TITLE
feat: support for extended/deploy edition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        version: [latest, latest:extended, latest:extended_withdeploy]
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v3
         with:
           command: hugo version
+          version: ${{ matrix.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v4
+        uses: asdf-vm/actions/plugin-test@v3
         with:
           command: hugo version

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ functionality.
 
 ```shell
 # Install extended/deploy hugo version
-asdf install hugo extended_withdeploy_0.154.3
+asdf install hugo extended_withdeploy-0.154.3
 
 # Manage it the same way
-asdf set --home hugo extended_withdeploy_0.154.3
+asdf set --home hugo extended_withdeploy-0.154.3
 ```
 
 See the [Editions section in the Hugo README](https://github.com/gohugoio/hugo/blob/master/README.md#editions) for more

--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@
 
 # Contents
 
+- [asdf-hugo  ](#asdf-hugo--)
+- [Build History](#build-history)
+- [Contents](#contents)
 - [Dependencies](#dependencies)
 - [Install](#install)
-- [Why?](#why)
+  - [Extended builds for Sass/SCSS support and deploy edition](#extended-builds-for-sassscss-support-and-deploy-edition)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -51,20 +54,36 @@ hugo version
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to
 install & manage versions.
 
-## Extended builds for Sass/SCSS support
+## Extended builds for Sass/SCSS support and deploy edition
 
-To install an extended Hugo version with Sass/SCSS support simply prefix the version number in the `asdf install` command with `extended_`.
+To install an extended Hugo version with Sass/SCSS support simply prefix the version number in the `asdf install`
+command with `extended_`.
 
 ```shell
 # Install extended hugo version
-asdf install hugo extended_0.85.0
+asdf install hugo extended_0.154.3
 
 # Now you can manage it like you're used to
-asdf global hugo extended_0.85.0
+asdf global hugo extended_0.154.3
 ```
 
-**NOTE**: The extended builds for hugo are only available for 64bit Linux, macOS, and Windows.
-See the asset list at https://github.com/gohugoio/hugo/releases/latest.
+There is also an "extended/deploy" variant which includes the extended build plus additional deployment/cloud
+functionality.
+
+```shell
+# Install extended/deploy hugo version
+asdf install hugo extended_withdeploy_0.154.3
+
+# Manage it the same way
+asdf global hugo extended_withdeploy_0.154.3
+```
+
+See the [Editions section in the Hugo README](https://github.com/gohugoio/hugo/blob/master/README.md#editions) for more
+details.
+
+**NOTE**: The extended builds for Hugo (including the with deploy edition) are only available for 64bit Linux, macOS,
+and Windows. See the asset list at https://github.com/gohugoio/hugo/releases/latest.
+
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ asdf set --home hugo extended_withdeploy-0.154.3
 See the [Editions section in the Hugo README](https://github.com/gohugoio/hugo/blob/master/README.md#editions) for more
 details.
 
-**NOTE**: The extended builds for Hugo (including the with deploy edition) are only available for 64bit Linux, macOS,
+**NOTE**: The extended builds for Hugo (including the with-deploy edition) are only available for 64bit Linux, macOS,
 and Windows. See the asset list at https://github.com/gohugoio/hugo/releases/latest.
 
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ hugo:
 
 ```shell
 # Show all installable versions
-asdf list-all hugo
+asdf list all hugo
 
 # Install specific version
 asdf install hugo latest
 
-# Set a version globally (on your ~/.tool-versions file)
-asdf global hugo latest
+# Set a version for your user (writes to your ~/.tool-versions)
+asdf set -u hugo latest
 
 # Now hugo commands are available
 hugo version
@@ -64,7 +64,7 @@ command with `extended_`.
 asdf install hugo extended_0.154.3
 
 # Now you can manage it like you're used to
-asdf global hugo extended_0.154.3
+asdf set -u hugo extended_0.154.3
 ```
 
 There is also an "extended/deploy" variant which includes the extended build plus additional deployment/cloud
@@ -75,7 +75,7 @@ functionality.
 asdf install hugo extended_withdeploy_0.154.3
 
 # Manage it the same way
-asdf global hugo extended_withdeploy_0.154.3
+asdf set --home hugo extended_withdeploy_0.154.3
 ```
 
 See the [Editions section in the Hugo README](https://github.com/gohugoio/hugo/blob/master/README.md#editions) for more

--- a/bin/list-all
+++ b/bin/list-all
@@ -8,4 +8,4 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 # shellcheck source=lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
-list_all_versions | sort_versions | xargs echo
+list_all_versions | sort_versions | expand_versions | xargs echo

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -138,6 +138,8 @@ download_release() {
   local version="$1"
   local version_path
   local filename="$2"
+  local major_version
+  local minor_version
   read -r version_path major_version minor_version <<<"$(parse_version "$version")"
   local platform
   platform=$(get_platform)

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -61,10 +61,10 @@ expand_versions() {
     fi
   done
 
-  # Print regular versions first, then extended, then extended_withdeploy
+  # Print regular versions first, then extended_withdeploy, then extended
   printf '%s\n' "${regular[@]:-}"
-  printf '%s\n' "${extended[@]:-}"
   printf '%s\n' "${extended_withdeploy[@]:-}"
+  printf '%s\n' "${extended[@]:-}"
 }
 
 # Parse a version string into a plain version path and its major/minor parts.

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -37,6 +37,36 @@ list_all_versions() {
   echo "$tags"
 }
 
+# Expand sorted versions with special variant tags.
+# For each version V (one per input line):
+# - emit V
+# - if V >= 0.43 emit extended_V
+# - if V >= 0.137 emit extended_withdeploy_V
+expand_versions() {
+  local regular=()
+  local extended=()
+  local extended_withdeploy=()
+
+  while IFS= read -r ver; do
+    [ -z "${ver}" ] && continue
+    regular+=("$ver")
+    read -r version_path major_version minor_version <<<"$(parse_version "$ver")"
+    if [[ "$major_version" =~ ^[0-9]+$ ]] && [[ "$minor_version" =~ ^[0-9]+$ ]]; then
+      if [ "$major_version" -eq 0 ] && [ "$minor_version" -ge 43 ]; then
+        extended+=("extended_${ver}")
+      fi
+      if [ "$major_version" -eq 0 ] && [ "$minor_version" -ge 137 ]; then
+        extended_withdeploy+=("extended_withdeploy_${ver}")
+      fi
+    fi
+  done
+
+  # Print regular versions first, then extended, then extended_withdeploy
+  printf '%s\n' "${regular[@]:-}"
+  printf '%s\n' "${extended[@]:-}"
+  printf '%s\n' "${extended_withdeploy[@]:-}"
+}
+
 # Parse a version string into a plain version path and its major/minor parts.
 # Supports prefixes like "extended_" and "extended_withdeploy_".
 parse_version() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -40,8 +40,8 @@ list_all_versions() {
 # Expand sorted versions with special variant tags.
 # For each version V (one per input line):
 # - emit V
-# - if V >= 0.43 emit extended_V
-# - if V >= 0.137 emit extended_withdeploy_V
+# - if V >= 0.43 emit extended-V
+# - if V >= 0.137 emit extended_withdeploy-V
 expand_versions() {
   local regular=()
   local extended=()


### PR DESCRIPTION
This PR adds support for [Hugo’s extended / deploy edition](https://github.com/gohugoio/hugo/blob/master/README.md#editions)

It also updates the `list` command to list these variants, which in turn addresses #7 by allowing asdf users to install the latest extended version with `asdf install hugo latest:extended`, and the extended/deploy version with `asdf install hugo latest:extended_withdeploy`.

The documentation has been updated to use Hugo asdf-vm v0.16.0+ compatible commands (see  https://asdf-vm.com/guide/upgrading-to-v0-16.html#breaking-changes ) and to explain how to properly install the extended/deploy version.

Finally, I’ve updated the CI build workflow to test these variants and downgraded the asdf plugin test action to v3, as builds were failing
(e.g., https://github.com/NeoHsu/asdf-hugo/actions/runs/20704098959)
due to an underlying bug in `asdf-vm/actions/plugin-test@v4`: https://github.com/asdf-vm/actions/issues/595

The detailed description below was AI generated (and reviewed by me).

---

This pull request introduces improved support for Hugo's extended and deploy editions in the asdf-hugo plugin. It adds logic to recognize and handle these variants, updates documentation to reflect the new installation options, and adjusts the build workflow for better test coverage. The most important changes are grouped below:

**Support for Hugo Extended and Deploy Editions:**

* Added the `expand_versions` function in `lib/utils.bash` to automatically generate variant tags (`extended`, `extended_withdeploy`) for Hugo versions that support them. This enables users to easily install extended and deploy editions using asdf.
* Updated the version parsing logic and download URLs to correctly handle both underscore and dash separators in variant names, ensuring the correct release assets are downloaded for all supported Hugo editions. [[1]](diffhunk://#diff-837b8f846cf319a2535e7719b9a7a34e8316e7472abea31f0f786440d0c30dd6L96-L103) [[2]](diffhunk://#diff-837b8f846cf319a2535e7719b9a7a34e8316e7472abea31f0f786440d0c30dd6L120-R166)

**Documentation Updates:**

* Expanded the `README.md` to document how to install and manage extended and deploy editions of Hugo, including updated example commands and links to upstream documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R48) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R86)

**Build and Test Workflow:**

* Modified the GitHub Actions workflow to test all supported Hugo variants (`latest`, `latest:extended`, `latest:extended_withdeploy`) across both Ubuntu and macOS, and reverted to a stable action version for compatibility.